### PR TITLE
Update /extract docs with actual limits

### DIFF
--- a/get-extract.mdx
+++ b/get-extract.mdx
@@ -593,7 +593,7 @@ When `url` is a file URL, the endpoint supports the following file formats:
 - OGG
 - WAV
 
-The maximum file size is 1 GB.
+The maximum file size is 200 MB. Videos longer than 55 minutes are not supported.
 
 ## Latency
 


### PR DESCRIPTION
Clarify file size and duration limits for the /extract endpoint.

Updates the documentation to specify the maximum file size of 200 MB and maximum video duration of 55 minutes, replacing the outdated 1 GB file size limit.

🤖 Generated with Claude Code

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/dumplingsoftware/dumplingsoftware/editor/rafalzawadzki%2Fextract-limits?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->