### PR TITLE
Update /extract endpoint pricing section

### DIFF
--- a/get-extract.mdx
+++ b/get-extract.mdx
@@ -605,8 +605,12 @@ Extraction always involves AI processing and returns a job ID (HTTP 202) for asy
 
 ## Pricing
 
+- 1 extraction minute = 5 credits (minimum 5 credits per request)
+
 <Info>
-  The extract endpoint is **free** during the beta period until **February 27, 2026**. No credits are consumed for extract requests during this period.
+  The extract endpoint is **free** during the beta period until **March 3, 2026**. No credits are consumed for extract requests during this period.
 </Info>
 
-No credits are charged for checking extraction job status.
+<Info>
+  No credits are charged for checking extraction job status.
+</Info>


### PR DESCRIPTION
Update the extract endpoint pricing documentation with:
- New pricing model: 5 credits per minute of video (minimum 5 credits per request)
- Updated free period to March 3, 2026
- Reformatted pricing section to match the /transcript endpoint style using bullet points and Info blocks