### PR TITLE
Remove outdated extract free-beta callout

### DIFF
--- a/get-extract.mdx
+++ b/get-extract.mdx
@@ -608,9 +608,5 @@ Extraction always involves AI processing and returns a job ID (HTTP 202) for asy
 - 1 extraction minute = 5 credits (minimum 5 credits per request)
 
 <Info>
-  The extract endpoint is **free** during the beta period until **March 3, 2026**. No credits are consumed for extract requests during this period.
-</Info>
-
-<Info>
   No credits are charged for checking extraction job status.
 </Info>


### PR DESCRIPTION
The /extract endpoint pricing section contained an outdated callout stating the endpoint was free during beta until March 3, 2026. That date has passed, so remove the callout.