### PR TITLE
seo: optimize supported-url-formats title/meta + add CTA

### DIFF
--- a/youtube/supported-url-formats.mdx
+++ b/youtube/supported-url-formats.mdx
@@ -1,8 +1,12 @@
 ---
-title: 'URL Formats'
-og:title: 'Supported YouTube URL formats | Supadata'
-description: 'Supported YouTube URL formats for videos, playlists, and channels.'
+title: 'Supported YouTube URL Formats'
+og:title: 'Supported YouTube URL Formats (Video, Playlist & Channel) | Supadata Docs'
+description: 'Complete list of supported YouTube URL formats for Supadata Transcript API — videos, shorts, playlists, and channels. Copy-paste ready examples.'
 ---
+
+<Note>
+  **Ready to extract transcripts?** → [Try the YouTube Transcript API](https://supadata.ai/youtube-transcript-api)
+</Note>
 
 ## Supported YouTube URL Formats
 


### PR DESCRIPTION
## What

Optimizes the [/youtube/supported-url-formats](https://docs.supadata.ai/youtube/supported-url-formats) page which ranks **#1** for 'youtube url format' (vol 60) but gets near-zero traffic due to weak title/meta.

## Changes

- **Title** (sidebar): `URL Formats` → `Supported YouTube URL Formats`
- **og:title**: `Supported YouTube URL formats | Supadata` → `Supported YouTube URL Formats (Video, Playlist & Channel) | Supadata Docs`
- **meta desc**: Generic → keyword-rich description mentioning Transcript API, videos/shorts/playlists/channels
- **H1**: `URL Formats` → `Supported YouTube URL Formats` (full keyword match)
- **CTA callout** at top: links to `supadata.ai/youtube-transcript-api` (internal PageRank flow)

## Expected Impact

- CTR improvement on #1 ranking (currently near-zero traffic despite top position)
- Better internal linking from docs → main product page for PageRank