### PR TITLE
Fix MCP config for cursor

### DIFF
--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -72,7 +72,7 @@ To use it in a conversation, click the **+** icon in the composer, select **More
     "command": "npx",
     "args": ["-y", "@supadata/mcp"],
     "env": {
-      "X_API_KEY": "your-api-key"
+      "SUPADATA_API_KEY": "your-api-key"
     }
   }
 }


### PR DESCRIPTION
Cursor was giving me errors that `SUPADATA_API_KEY` env variable was missing.