### PR TITLE
seo: optimize URL formats page title/description for 'youtube url format' queries

### DIFF
--- a/youtube/supported-url-formats.mdx
+++ b/youtube/supported-url-formats.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'URL Formats'
-og:title: 'Supported YouTube URL formats | Supadata'
-description: 'Supported YouTube URL formats for videos, playlists, and channels.'
+title: 'YouTube URL Format Guide: All Supported Formats'
+og:title: 'YouTube URL Format Guide: Video, Playlist & Channel Formats | Supadata'
+description: 'Complete guide to YouTube URL formats. All supported YouTube video URL formats, playlist URLs, and channel URL formats accepted by the Supadata API.'
 ---
 
 ## Supported YouTube URL Formats


### PR DESCRIPTION
## Summary

Updated the `/youtube/supported-url-formats` docs page to capture 'youtube url format' search queries.

### Changes
- **Title:** `URL Formats` → `YouTube URL Format Guide: All Supported Formats`
- **og:title:** Updated to include 'youtube url format' keyword
- **Description:** Expanded to include 'youtube url format', 'video URL formats', 'channel URL formats' — matches searcher intent

### SEO Impact
The page has valuable content about URL formats but the title/meta were too generic. These changes align the page with actual search queries.