### PR TITLE
seo: improve MCP docs page title for CTR

### DIFF
--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -1,6 +1,6 @@
 ---
-title: "MCP"
-description: "Model Context Protocol server for AI-powered web and video scraping"
+title: "Supadata MCP Server — YouTube Transcripts & Web Scraping for AI Agents"
+description: "Connect Claude, Cursor, and ChatGPT to YouTube transcripts and web scraping via the Supadata MCP server. Get video transcripts, scrape websites, and crawl pages directly in your AI assistant."
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

The MCP docs page title was just 'MCP' — far too thin to rank or get clicks.

### Changes
- **Before title:** `MCP`
- **After title:** `Supadata MCP Server — YouTube Transcripts & Web Scraping for AI Agents`
- **Description:** Updated to be keyword-rich and click-worthy, targeting 'supadata mcp', 'youtube transcript mcp server', 'web scraping mcp'